### PR TITLE
Update relational_rnn_general.py

### DIFF
--- a/models/relational_rnn_general.py
+++ b/models/relational_rnn_general.py
@@ -171,7 +171,7 @@ class RelationalMemory(nn.Module):
         q, k, v = torch.split(qkv_transpose, [self.key_size, self.key_size, self.value_size], -1)
 
         # scale q with d_k, the dimensionality of the key vectors
-        q *= (self.key_size ** -0.5)
+        q = q * (self.key_size ** -0.5)
 
         # make it [B, H, N, N]
         dot_product = torch.matmul(q, k.permute(0, 1, 3, 2))


### PR DESCRIPTION
Fix issue: RuntimeError: Output 0 of SplitWithSizesBackward0 is a view and is being modified inplace. This view is the output of a function that returns multiple views. Such functions do not allow the output views to be modified inplace. You should replace the inplace operation by an out-of-place one.