### PR TITLE
Better Exception handling and Added preprocessing step

### DIFF
--- a/instructor/real_data/instructor.py
+++ b/instructor/real_data/instructor.py
@@ -40,8 +40,8 @@ class BasicInstructor:
         try:
             self.train_data = GenDataIter(cfg.train_data)
             self.test_data = GenDataIter(cfg.test_data, if_test_data=True)
-        except:
-            pass
+        except Exception as e:
+            print(f'Could not load train and test data: {e}')
 
         try:
             self.train_data_list = [GenDataIter(cfg.cat_train_data.format(i)) for i in range(cfg.k_label)]
@@ -52,8 +52,8 @@ class BasicInstructor:
 
             self.train_samples_list = [self.train_data_list[i].target for i in range(cfg.k_label)]
             self.clas_samples_list = [self.clas_data_list[i].target for i in range(cfg.k_label)]
-        except:
-            pass
+        except Exception as e:
+            print(f'Could not create train_samples_list and class_samples_list: {e}')
 
         # Criterion
         self.mle_criterion = nn.NLLLoss()

--- a/utils/data_loader.py
+++ b/utils/data_loader.py
@@ -82,6 +82,7 @@ class GenDataIter:
     def load_data(self, filename):
         """Load real data from local file"""
         self.tokens = get_tokenlized(filename)
+        self.tokens = [tokens for tokens in self.tokens if len(tokens) > 0]
         samples_index = tokens_to_tensor(self.tokens, self.word2idx_dict)
         return self.prepare(samples_index)
 


### PR DESCRIPTION
The error stemming from the CATGAN instructor for real data when the token size generated is of length 0 leads to error train_data is not an attribute of CatGAN instructor and test_data is not an attribute of CatGAN instructor. 